### PR TITLE
docs: fix spelling error in forward_inverse_rendering.ipynb

### DIFF
--- a/inverse_rendering/forward_inverse_rendering.ipynb
+++ b/inverse_rendering/forward_inverse_rendering.ipynb
@@ -59,7 +59,7 @@
     "\n",
     "Forward mode differentiable rendering begins analogously to reverse mode, by marking the parameters of interest as differentiable (in this example, we do so manually instead of using an `Optimizer`). \n",
     "\n",
-    "Our goal here is to visualize how changes of the green wall's color affect the final rendered image. Note that we are rendering this image using a physically-based *path tracer*, which means that it accounts for globlal illumination, reflection, refraction, and so on. Gradients computated from this simulation will also expose such effects."
+    "Our goal here is to visualize how changes of the green wall's color affect the final rendered image. Note that we are rendering this image using a physically-based *path tracer*, which means that it accounts for global illumination, reflection, refraction, and so on. Gradients computated from this simulation will also expose such effects."
    ]
   },
   {


### PR DESCRIPTION
'globlal' -> 'global'