### PR TITLE
Use tensor device for PyTorch interop notebook

### DIFF
--- a/how_to_guides/image_io_and_manipulation.ipynb
+++ b/how_to_guides/image_io_and_manipulation.ipynb
@@ -549,7 +549,7 @@
    ],
    "source": [
     "# Set a variant (in order of preference)\n",
-    "mi.set_variant('cuda_ad_rgb', 'llvm_ad_rgb')\n",
+    "mi.set_variant('cuda_ad_rgb', 'llvm_ad_rgb', 'amd_ad_rgb')\n",
     "\n",
     "# Use the `box` reconstruction filter\n",
     "scene_description = mi.cornell_box()\n",

--- a/how_to_guides/mesh_io_and_manipulation.ipynb
+++ b/how_to_guides/mesh_io_and_manipulation.ipynb
@@ -21,7 +21,7 @@
     "import drjit as dr\n",
     "import mitsuba as mi\n",
     "\n",
-    "mi.set_variant(\"cuda_ad_rgb\", \"llvm_ad_rgb\")"
+    "mi.set_variant(\"cuda_ad_rgb\", \"llvm_ad_rgb\", \"amd_ad_rgb\")"
    ]
   },
   {

--- a/how_to_guides/use_optimizers.ipynb
+++ b/how_to_guides/use_optimizers.ipynb
@@ -32,7 +32,7 @@
     "import mitsuba as mi\n",
     "import drjit as dr \n",
     "\n",
-    "mi.set_variant('llvm_ad_rgb')"
+    "mi.set_variant('llvm_ad_rgb', 'amd_ad_rgb')"
    ]
   },
   {

--- a/inverse_rendering/caustics_optimization.ipynb
+++ b/inverse_rendering/caustics_optimization.ipynb
@@ -74,7 +74,7 @@
     "import drjit as dr\n",
     "import mitsuba as mi\n",
     "\n",
-    "mi.set_variant('cuda_ad_rgb', 'llvm_ad_rgb')"
+    "mi.set_variant('cuda_ad_rgb', 'llvm_ad_rgb', 'amd_ad_rgb')"
    ]
   },
   {

--- a/inverse_rendering/forward_inverse_rendering.ipynb
+++ b/inverse_rendering/forward_inverse_rendering.ipynb
@@ -46,7 +46,7 @@
     "import drjit as dr\n",
     "import mitsuba as mi\n",
     "\n",
-    "mi.set_variant('llvm_ad_rgb')\n",
+    "mi.set_variant('llvm_ad_rgb', 'amd_ad_rgb')\n",
     "\n",
     "scene = mi.load_file('../scenes/cbox.xml')"
    ]

--- a/inverse_rendering/gradient_based_opt.ipynb
+++ b/inverse_rendering/gradient_based_opt.ipynb
@@ -76,7 +76,7 @@
     "import drjit as dr\n",
     "import mitsuba as mi\n",
     "\n",
-    "mi.set_variant('llvm_ad_rgb')"
+    "mi.set_variant('llvm_ad_rgb', 'amd_ad_rgb')"
    ]
   },
   {

--- a/inverse_rendering/object_pose_estimation.ipynb
+++ b/inverse_rendering/object_pose_estimation.ipynb
@@ -72,7 +72,7 @@
     "import drjit as dr\n",
     "import mitsuba as mi\n",
     "\n",
-    "mi.set_variant('cuda_ad_rgb', 'llvm_ad_rgb')"
+    "mi.set_variant('cuda_ad_rgb', 'llvm_ad_rgb', 'amd_ad_rgb')"
    ]
   },
   {

--- a/inverse_rendering/polarizer_optimization.ipynb
+++ b/inverse_rendering/polarizer_optimization.ipynb
@@ -60,7 +60,7 @@
     "import drjit as dr \n",
     "import mitsuba as mi\n",
     "\n",
-    "mi.set_variant('llvm_ad_rgb_polarized')\n",
+    "mi.set_variant('llvm_ad_rgb_polarized', 'amd_ad_rgb_polarized')\n",
     "\n",
     "scene = mi.load_file('../scenes/polarizers.xml')"
    ]

--- a/inverse_rendering/projective_sampling_integrators.ipynb
+++ b/inverse_rendering/projective_sampling_integrators.ipynb
@@ -61,7 +61,7 @@
     "import numpy as np\n",
     "import os\n",
     "\n",
-    "mi.set_variant('cuda_ad_rgb', 'llvm_ad_rgb')"
+    "mi.set_variant('cuda_ad_rgb', 'llvm_ad_rgb', 'amd_ad_rgb')"
    ]
   },
   {

--- a/inverse_rendering/pytorch_mitsuba_interoperability.ipynb
+++ b/inverse_rendering/pytorch_mitsuba_interoperability.ipynb
@@ -59,7 +59,7 @@
    "source": [
     "import drjit as dr\n",
     "import mitsuba as mi\n",
-    "mi.set_variant('cuda_ad_rgb', 'llvm_ad_rgb')"
+    "mi.set_variant('cuda_ad_rgb', 'llvm_ad_rgb', 'amd_ad_rgb')"
    ]
   },
   {
@@ -343,7 +343,7 @@
     "        return torch.stack([c.view(res, res) for c in rgb], dim=2)\n",
     "\n",
     "model = Model1()\n",
-    "if 'cuda' in mi.variant():\n",
+    "if textures[0].torch().is_cuda:\n",
     "    model = model.cuda()"
    ]
   },

--- a/inverse_rendering/radiance_field_reconstruction.ipynb
+++ b/inverse_rendering/radiance_field_reconstruction.ipynb
@@ -46,7 +46,7 @@
    "source": [
     "import drjit as dr\n",
     "import mitsuba as mi\n",
-    "mi.set_variant('cuda_ad_rgb', 'llvm_ad_rgb')"
+    "mi.set_variant('cuda_ad_rgb', 'llvm_ad_rgb', 'amd_ad_rgb')"
    ]
   },
   {

--- a/inverse_rendering/shape_optimization.ipynb
+++ b/inverse_rendering/shape_optimization.ipynb
@@ -56,7 +56,7 @@
     "import matplotlib.pyplot as plt # We'll also want to plot some outputs\n",
     "import os\n",
     "\n",
-    "mi.set_variant('cuda_ad_rgb', 'llvm_ad_rgb')"
+    "mi.set_variant('cuda_ad_rgb', 'llvm_ad_rgb', 'amd_ad_rgb')"
    ]
   },
   {

--- a/inverse_rendering/volume_optimization.ipynb
+++ b/inverse_rendering/volume_optimization.ipynb
@@ -55,7 +55,7 @@
     "import drjit as dr\n",
     "import mitsuba as mi\n",
     "\n",
-    "mi.set_variant('cuda_ad_rgb', 'llvm_ad_rgb')"
+    "mi.set_variant('cuda_ad_rgb', 'llvm_ad_rgb', 'amd_ad_rgb')"
    ]
   },
   {

--- a/others/bsdf_deep_dive.ipynb
+++ b/others/bsdf_deep_dive.ipynb
@@ -47,7 +47,7 @@
     "import drjit as dr\n",
     "import mitsuba as mi\n",
     "\n",
-    "mi.set_variant('llvm_ad_rgb')"
+    "mi.set_variant('llvm_ad_rgb', 'amd_ad_rgb')"
    ]
   },
   {

--- a/others/custom_plugin.ipynb
+++ b/others/custom_plugin.ipynb
@@ -50,7 +50,7 @@
     "import drjit as dr\n",
     "import mitsuba as mi\n",
     "\n",
-    "mi.set_variant('llvm_ad_rgb')"
+    "mi.set_variant('llvm_ad_rgb', 'amd_ad_rgb')"
    ]
   },
   {

--- a/others/granular_phase_function.ipynb
+++ b/others/granular_phase_function.ipynb
@@ -60,7 +60,7 @@
     "import drjit as dr\n",
     "import mitsuba as mi\n",
     "\n",
-    "mi.set_variant('llvm_ad_rgb')"
+    "mi.set_variant('llvm_ad_rgb', 'amd_ad_rgb')"
    ]
   },
   {

--- a/rendering/editing_a_scene.ipynb
+++ b/rendering/editing_a_scene.ipynb
@@ -48,7 +48,7 @@
    "source": [
     "import drjit as dr\n",
     "import mitsuba as mi\n",
-    "mi.set_variant('llvm_ad_rgb')\n",
+    "mi.set_variant('llvm_ad_rgb', 'amd_ad_rgb')\n",
     "\n",
     "scene = mi.load_file(\"../scenes/simple.xml\")"
    ]

--- a/rendering/polarized_rendering.ipynb
+++ b/rendering/polarized_rendering.ipynb
@@ -84,7 +84,7 @@
    },
    "outputs": [],
    "source": [
-    "mi.set_variant('llvm_ad_spectral_polarized')"
+    "mi.set_variant('llvm_ad_spectral_polarized', 'amd_ad_spectral_polarized')"
    ]
   },
   {

--- a/rendering/scripting_renderer.ipynb
+++ b/rendering/scripting_renderer.ipynb
@@ -53,7 +53,7 @@
     "import mitsuba as mi\n",
     "import drjit as dr\n",
     "\n",
-    "mi.set_variant('llvm_ad_rgb')\n",
+    "mi.set_variant('llvm_ad_rgb', 'amd_ad_rgb')\n",
     "\n",
     "scene = mi.load_file('../scenes/cbox.xml')"
    ]


### PR DESCRIPTION
This PR updates tutorial notebooks so they can run directly on AMD-enabled Mitsuba builds.

- Adds AMD variants to existing `mi.set_variant(...)` choices, e.g. `amd_ad_rgb`, `amd_ad_rgb_polarized`, and `amd_ad_spectral_polarized`.
- Keeps the existing CUDA/LLVM choices in place and only extends the variant lists where needed.
- Updates the PyTorch interop notebook to move the PyTorch model based on the actual tensor device instead of checking for `"cuda"` in the Mitsuba variant name.
- Does not change notebook dependency installation cells or iteration budgets.

## Validation

- Parsed all modified notebooks as valid JSON.
- Verified the referenced AMD variants are available in the local Mitsuba AMD build.